### PR TITLE
Replace calling "curl" by using Python's "request" module

### DIFF
--- a/ena_upload/ena_upload.py
+++ b/ena_upload/ena_upload.py
@@ -337,14 +337,14 @@ def submit_data(file_paths, password, webin_id):
 def columns_to_update(df):
     '''
     returns the column names where contains the cells to update
-        used after processing the reciept xmls
+        used after processing the receipt xmls
     '''
     return df[df.apply(lambda x: x == 'to_update')].dropna(axis=1, how='all').columns
 
 
 def send_schemas(schema_xmls, url, webin_id, password):
     '''submit compiled XML files to the given ENA server
-    return the reeipt object after the submission.
+    return the receipt object after the submission.
 
     schema_xmls -- dictionary of schema and the corresponding XML file name
                e.g.  {'submission':'submission.xml',
@@ -376,7 +376,7 @@ def send_schemas(schema_xmls, url, webin_id, password):
 
 
 def process_receipt(receipt, action):
-    '''Process submission reciept from ENA.
+    '''Process submission receipt from ENA.
 
     :param receipt: a string of XML
 

--- a/ena_upload/ena_upload.py
+++ b/ena_upload/ena_upload.py
@@ -8,14 +8,12 @@ import os
 import sys
 import subprocess
 import shlex
-import json
 import argparse
 import yaml
 import hashlib
 import ftplib
 import requests
 import uuid
-import datetime
 from genshi.template import TemplateLoader
 from lxml import etree
 import pandas as pd

--- a/ena_upload/ena_upload.py
+++ b/ena_upload/ena_upload.py
@@ -343,6 +343,7 @@ def columns_to_update(df):
     '''
     return df[df.apply(lambda x: x == 'to_update')].dropna(axis=1, how='all').columns
 
+
 def get_cmd_line(schema_xmls, url, webin_id, password):
     '''submit compiled XML files to the given ENA server
     return the reciept object after the submission.
@@ -372,39 +373,6 @@ def get_cmd_line(schema_xmls, url, webin_id, password):
     cmd_line = f'curl -u {webin_id}:{password} {sources} {url}'
 
     return cmd_line
-
-def send_schemas(schema_xmls, url, webin_id, password):
-    '''submit compiled XML files to the given ENA server
-    return the reciept object after the submission.
-
-    schema_xmls -- dictionary of schema and the corresponding XML file name
-               e.g.  {'submission':'submission.xml',
-                      'study':'study.xml',
-                      'run':'run.xml',
-                      'sample':'sample.xml',
-                      'experiment':'experiment.xml'}
-
-    url -- ENA servers
-           test:
-                https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA
-           production:
-                https://www.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA
-
-    webin_id -- ENA webin ID of user
-    password -- ENA password of user
-    '''
-
-
-    sources = {schema.upper(): source for schema, source in schema_xmls.items()}
-
-    session = requests.Session()
-    session.trust_env = False
-    r = session.post(f"{url}",
-                    auth=(webin_id,password),
-                    files=sources)
-
-    print(r.text)
-    return r
 
 
 def process_receipt(reciept, action):
@@ -769,13 +737,11 @@ def main ():
 
     submit_cmd_line = get_cmd_line(schema_xmls, url, webin_id, password)
 
-    print (f'\nSubmitting XMLs to ENA server: {url}')
-    # receipt = send_schemas(schema_xmls, url, webin_id, password).text
+    print(f'\nSubmitting XMLs to ENA server: {url}')
     receipt = run_cmd(submit_cmd_line)
-    print ("Printing receipt to ./receipt.xml")
+    print("Printing receipt to ./receipt.xml")
     with open('receipt.txt', 'w') as fw:
         fw.write(receipt.decode("utf-8") )
-        #fw.write(receipt) #.decode("utf-8")
     try:
         schema_update = process_receipt(receipt, action)
     except ValueError:

--- a/ena_upload/ena_upload.py
+++ b/ena_upload/ena_upload.py
@@ -13,6 +13,7 @@ import argparse
 import yaml
 import hashlib
 import ftplib
+import requests
 import uuid
 import datetime
 from genshi.template import TemplateLoader
@@ -299,15 +300,13 @@ def get_taxon_id(scientific_name):
     """
     # endpoint for taxonomy id
     url = 'http://www.ebi.ac.uk/ena/taxonomy/rest/scientific-name'
-
+    session = requests.Session()
+    session.trust_env = False
     # url encoding: space -> %20
     scientific_name = '%20'.join(scientific_name.strip().split())
-
-    cmd_line = f'curl -L {url}/{scientific_name}'
-    output = run_cmd(cmd_line).decode("utf-8")
-    #print(output)
+    r = session.get(f"{url}/{scientific_name}")
     try:
-        taxon_id = json.loads(output)[0]['taxId']
+        taxon_id = r.json()[0]['taxId']
         return taxon_id
     except ValueError:
         msg = f'Oops, no taxon ID avaible for {scientific_name}. Is it a valid scientific name?'
@@ -344,7 +343,6 @@ def columns_to_update(df):
     '''
     return df[df.apply(lambda x: x == 'to_update')].dropna(axis=1, how='all').columns
 
-
 def get_cmd_line(schema_xmls, url, webin_id, password):
     '''submit compiled XML files to the given ENA server
     return the reciept object after the submission.
@@ -374,6 +372,39 @@ def get_cmd_line(schema_xmls, url, webin_id, password):
     cmd_line = f'curl -u {webin_id}:{password} {sources} {url}'
 
     return cmd_line
+
+def send_schemas(schema_xmls, url, webin_id, password):
+    '''submit compiled XML files to the given ENA server
+    return the reciept object after the submission.
+
+    schema_xmls -- dictionary of schema and the corresponding XML file name
+               e.g.  {'submission':'submission.xml',
+                      'study':'study.xml',
+                      'run':'run.xml',
+                      'sample':'sample.xml',
+                      'experiment':'experiment.xml'}
+
+    url -- ENA servers
+           test:
+                https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA
+           production:
+                https://www.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA
+
+    webin_id -- ENA webin ID of user
+    password -- ENA password of user
+    '''
+
+
+    sources = {schema.upper(): source for schema, source in schema_xmls.items()}
+
+    session = requests.Session()
+    session.trust_env = False
+    r = session.post(f"{url}",
+                    auth=(webin_id,password),
+                    files=sources)
+
+    print(r.text)
+    return r
 
 
 def process_receipt(reciept, action):
@@ -739,10 +770,12 @@ def main ():
     submit_cmd_line = get_cmd_line(schema_xmls, url, webin_id, password)
 
     print (f'\nSubmitting XMLs to ENA server: {url}')
+    # receipt = send_schemas(schema_xmls, url, webin_id, password).text
     receipt = run_cmd(submit_cmd_line)
     print ("Printing receipt to ./receipt.xml")
     with open('receipt.txt', 'w') as fw:
         fw.write(receipt.decode("utf-8") )
+        #fw.write(receipt) #.decode("utf-8")
     try:
         schema_update = process_receipt(receipt, action)
     except ValueError:

--- a/ena_upload/templates/SRA.common.xsd
+++ b/ena_upload/templates/SRA.common.xsd
@@ -908,8 +908,7 @@
             <xs:enumeration value="HiSeq X Five"/>
             <xs:enumeration value="Illumina HiSeq 3000"/>
             <xs:enumeration value="Illumina HiSeq 4000"/>
-            <xs:enumeration value="Illumina NovaSeq 6000"/>
-            <xs:enumeration value="Illumina NextSeq 550"/>
+            <xs:enumeration value="NextSeq 550"/>
             <xs:enumeration value="unspecified"/>
         </xs:restriction>
     </xs:simpleType>

--- a/ena_upload/templates/SRA.common.xsd
+++ b/ena_upload/templates/SRA.common.xsd
@@ -908,7 +908,8 @@
             <xs:enumeration value="HiSeq X Five"/>
             <xs:enumeration value="Illumina HiSeq 3000"/>
             <xs:enumeration value="Illumina HiSeq 4000"/>
-            <xs:enumeration value="NextSeq 550"/>
+            <xs:enumeration value="Illumina NovaSeq 6000"/>
+            <xs:enumeration value="Illumina NextSeq 550"/>
             <xs:enumeration value="unspecified"/>
         </xs:restriction>
     </xs:simpleType>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ genshi
 lxml
 pandas
 pyyaml
+requests


### PR DESCRIPTION
As I had recurring problems retrieving the taxon_id via curl, I replaced the instances were curl was used for communication with Python's `requests` module (https://docs.python-requests.org/en/master/).

This eliminates the curl dependency and should be a cleaner implementation that is not relying on external program calls. 

For transferring the XML data to EBI, I renamed the `get_cmd_line` method to `send_schemas`. 

Additional minor fixes: 
 - fixing typo "reciept" in method `process_receipt`
 - writing receipt to `receipt.xml`, not `receipt.txt`