### PR TITLE
Generating md5 hash when not given with -no_upload flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ More information on how ENA wants to receive the files can be found [here](https
 
 **Note for data upload:** 
 Uploaded files are persistently stored on the ENA server after the upload for some time. 
-Thus, if multiple test submission are performed, it is possible to skip the data upload with `--no_upload` in
+Thus, if multiple test submission are performed, it is possible to skip the data upload with `--no_data_upload` in
 subsequent submissions.
 This also allows uploading (large) datasets separately e.g. with [aspera](https://ena-docs.readthedocs.io/en/latest/submit/fileprep/upload.html).
-For the `--no_upload` argument,  data file(s) still need to be provided with `--data` 
+For the `--no_data_upload` argument,  data file(s) still need to be provided with `--data` 
 if a RUN object is submitted in order to generate MD5 sums.  
 
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ All supported arguments:
   --tool TOOL_NAME      specify the name of the tool this submission is done with. Default: ena-upload-cli
   --tool_version TOOL_VERSION
                         specify the version of the tool this submission is done with
-  --no_upload           Indicate if no upload should be performed and you like to submit a RUN object (e.g. if uploaded was done separately).
+  --no_data_upload           Indicate if no upload should be performed and you like to submit a RUN object (e.g. if uploaded was done separately).
   --secret SECRET       .secret.yml file containing the password and Webin ID of your ENA account
   -d, --dev             flag to use the dev/sandbox endpoint of ENA
 ```

--- a/ena_upload/ena_upload.py
+++ b/ena_upload/ena_upload.py
@@ -715,16 +715,12 @@ def main():
             # a dictionary of filename:file_path
             # ? do I have to define the absolute path
             df = schema_targets['run']
-
-            if args.no_upload:
-                file_paths = {}
-                print("No files will be uploaded, remove `--no_upload' argument to perform upload.")
-            else:  # check supplied datafiles only if doing upload
-                file_paths = {os.path.basename(path): os.path.abspath(path)
-                                                   for path in args.data}
-                # check if file names identical between command line and table
-                # if not, system exits
-                check_filenames(file_paths, df)
+               
+            file_paths = {os.path.basename(path): os.path.abspath(path)
+                                                for path in args.data}
+            # check if file names identical between command line and table
+            # if not, system exits
+            check_filenames(file_paths, df)
 
             # generate MD5 sum if not supplied in table
             if not check_file_checksum(df):
@@ -742,6 +738,8 @@ def main():
             # submit data to webin ftp server
             if not args.no_upload:
                 submit_data(file_paths, password, webin_id)
+            else:
+                print("No files will be uploaded, remove `--no_upload' argument to perform upload.")
 
         # when adding sample
         # update schema_targets with taxon ids or scientific names

--- a/ena_upload/ena_upload.py
+++ b/ena_upload/ena_upload.py
@@ -615,7 +615,7 @@ def process_args():
                         default=__version__,
                         help='specify the version of the tool this submission is done with')
 
-    parser.add_argument('--no_upload',
+    parser.add_argument('--no_data_upload',
                         default=False,
                         action="store_true",
                         help='Indicate if no upload should be performed and you like to submit a RUN object (e.g. if uploaded was done separately).')
@@ -736,10 +736,10 @@ def main():
             schema_targets['run'] = df
 
             # submit data to webin ftp server
-            if not args.no_upload:
+            if not args.no_data_upload:
                 submit_data(file_paths, password, webin_id)
             else:
-                print("No files will be uploaded, remove `--no_upload' argument to perform upload.")
+                print("No files will be uploaded, remove `--no_data_upload' argument to perform upload.")
 
         # when adding sample
         # update schema_targets with taxon ids or scientific names


### PR DESCRIPTION
This will prevent an error with the when the md5 checksum is not given.

and changed to a more clear flag: --no_upload -> --no_data_upload