### PR TITLE
Adding back tool name to sample metadata

### DIFF
--- a/ena_upload/templates/ENA_template_samples.xml
+++ b/ena_upload/templates/ENA_template_samples.xml
@@ -6,14 +6,6 @@ def attributetest(row, column):
         return True 
     else:
         return False
-{%- if 'mandatory' not in attributes.values() %}
-def onlyoptional(row):
-    attributelist = {{ attributes.keys() | list }}
-    for column in attributelist:
-        if hasattr(row, column) and pd.notna(row[column]) and not row[column].isspace() and str(row[column]).lower() not in ['nan', 'na']:
-            return True
-    return False
-{%- endif %}
 ?>
 <SAMPLE_SET xmlns:py="http://genshi.edgewall.org/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -29,9 +21,6 @@ def onlyoptional(row):
             </py:if>
         </SAMPLE_NAME>
         <DESCRIPTION>${row.sample_description}</DESCRIPTION>
-        {%- if 'mandatory' not in attributes.values() %}
-        <py:if test="onlyoptional(row)">
-        {%- endif %}
         <SAMPLE_ATTRIBUTES>
             {%- for key, value in attributes.items() %}
             {%- if value == 'mandatory' %}
@@ -48,10 +37,15 @@ def onlyoptional(row):
             </py:if>
             {%- endif %}
             {%- endfor %}
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
-        {%- if 'mandatory' not in attributes.values() %}
-        </py:if>
-        {%- endif %}
     </SAMPLE>
     </py:for>
 </SAMPLE_SET>

--- a/ena_upload/templates/ENA_template_samples_ERC000011.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000011.xml
@@ -6,12 +6,6 @@ def attributetest(row, column):
         return True 
     else:
         return False
-def onlyoptional(row):
-    attributelist = ['cell_type', 'dev_stage', 'germline', 'tissue_lib', 'tissue_type', 'collection_date', 'isolation_source', 'lat_lon', 'collected_by', 'geographic location (country and/or sea)', 'geographic location (region and locality)', 'identified_by', 'environmental_sample', 'mating_type', 'sex', 'lab_host', 'host scientific name', 'bio_material', 'culture_collection', 'specimen_voucher', 'cultivar', 'ecotype', 'isolate', 'sub_species', 'variety', 'sub_strain', 'cell_line', 'serotype', 'serovar', 'strain']
-    for column in attributelist:
-        if hasattr(row, column) and pd.notna(row[column]) and not row[column].isspace() and str(row[column]).lower() not in ['nan', 'na']:
-            return True
-    return False
 ?>
 <SAMPLE_SET xmlns:py="http://genshi.edgewall.org/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -27,7 +21,6 @@ def onlyoptional(row):
             </py:if>
         </SAMPLE_NAME>
         <DESCRIPTION>${row.sample_description}</DESCRIPTION>
-        <py:if test="onlyoptional(row)">
         <SAMPLE_ATTRIBUTES>
             <py:if test="attributetest(row, 'cell_type')">
             <SAMPLE_ATTRIBUTE>
@@ -209,8 +202,15 @@ def onlyoptional(row):
                 <VALUE>${row['strain']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
-        </py:if>
     </SAMPLE>
     </py:for>
 </SAMPLE_SET>

--- a/ena_upload/templates/ENA_template_samples_ERC000012.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000012.xml
@@ -466,6 +466,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000013.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000013.xml
@@ -552,6 +552,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000014.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000014.xml
@@ -594,6 +594,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000015.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000015.xml
@@ -498,6 +498,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000016.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000016.xml
@@ -492,6 +492,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000017.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000017.xml
@@ -498,6 +498,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000018.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000018.xml
@@ -540,6 +540,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000019.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000019.xml
@@ -680,6 +680,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000020.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000020.xml
@@ -624,6 +624,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000021.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000021.xml
@@ -644,6 +644,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000022.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000022.xml
@@ -632,6 +632,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000023.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000023.xml
@@ -534,6 +534,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000024.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000024.xml
@@ -784,6 +784,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000025.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000025.xml
@@ -570,6 +570,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000027.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000027.xml
@@ -788,6 +788,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000028.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000028.xml
@@ -130,6 +130,14 @@ def attributetest(row, column):
                 <VALUE>${row['strain']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000029.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000029.xml
@@ -278,6 +278,14 @@ def attributetest(row, column):
                 <VALUE>${row['isolation source non-host-associated']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000030.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000030.xml
@@ -170,6 +170,14 @@ def attributetest(row, column):
                 <VALUE>${row['Further Details']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000031.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000031.xml
@@ -442,6 +442,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000032.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000032.xml
@@ -352,6 +352,14 @@ def attributetest(row, column):
                 <VALUE>${row['isolation source non-host-associated']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000033.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000033.xml
@@ -214,6 +214,14 @@ def attributetest(row, column):
                 <VALUE>${row['isolation source non-host-associated']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000034.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000034.xml
@@ -80,6 +80,14 @@ def attributetest(row, column):
                 <VALUE>${row['Further Details']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000035.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000035.xml
@@ -6,12 +6,6 @@ def attributetest(row, column):
         return True 
     else:
         return False
-def onlyoptional(row):
-    attributelist = ['cell_type', 'dev_stage', 'organism part', 'ploidy', 'infect', 'protocol', 'sampling time point', 'initial time point', 'growth condition', 'genotype', 'sex', 'age', 'genetic modification', 'phenotype', 'cellular component', 'individual', 'disease staging', 'immunoprecipitate', 'replicate', 'cultivar', 'ecotype', 'cell_line', 'strain', 'time', 'dose', 'chemical compound', 'experimental factor 1', 'experimental factor 2', 'experimental factor 3', 'experimental factor 4', 'experimental factor 5', 'block', 'environmental stress', 'environmental history']
-    for column in attributelist:
-        if hasattr(row, column) and pd.notna(row[column]) and not row[column].isspace() and str(row[column]).lower() not in ['nan', 'na']:
-            return True
-    return False
 ?>
 <SAMPLE_SET xmlns:py="http://genshi.edgewall.org/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -27,7 +21,6 @@ def onlyoptional(row):
             </py:if>
         </SAMPLE_NAME>
         <DESCRIPTION>${row.sample_description}</DESCRIPTION>
-        <py:if test="onlyoptional(row)">
         <SAMPLE_ATTRIBUTES>
             <py:if test="attributetest(row, 'cell_type')">
             <SAMPLE_ATTRIBUTE>
@@ -233,8 +226,15 @@ def onlyoptional(row):
                 <VALUE>${row['environmental history']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
-        </py:if>
     </SAMPLE>
     </py:for>
 </SAMPLE_SET>

--- a/ena_upload/templates/ENA_template_samples_ERC000036.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000036.xml
@@ -152,6 +152,14 @@ def attributetest(row, column):
                 <VALUE>${row['population size of the catchment area']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000037.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000037.xml
@@ -606,6 +606,14 @@ def attributetest(row, column):
                 <VALUE>${row['perturbation']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000038.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000038.xml
@@ -160,6 +160,14 @@ def attributetest(row, column):
                 <VALUE>${row['chemical compound']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000039.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000039.xml
@@ -180,6 +180,14 @@ def attributetest(row, column):
                 <VALUE>${row['isolation source non-host-associated']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000040.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000040.xml
@@ -126,6 +126,14 @@ def attributetest(row, column):
                 <VALUE>${row['Further Details']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000041.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000041.xml
@@ -158,6 +158,14 @@ def attributetest(row, column):
                 <VALUE>${row['Further Details']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000043.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000043.xml
@@ -140,6 +140,14 @@ def attributetest(row, column):
                 <VALUE>${row['Further Details']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000044.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000044.xml
@@ -114,6 +114,14 @@ def attributetest(row, column):
                 <VALUE>${row['isolation source host-associated']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000045.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000045.xml
@@ -64,6 +64,14 @@ def attributetest(row, column):
                 <VALUE>${row['serotype']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000047.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000047.xml
@@ -328,6 +328,14 @@ def attributetest(row, column):
                 <VALUE>${row['relationship to oxygen']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000048.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000048.xml
@@ -332,6 +332,14 @@ def attributetest(row, column):
                 <VALUE>${row['relationship to oxygen']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000049.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000049.xml
@@ -406,6 +406,14 @@ def attributetest(row, column):
                 <VALUE>${row['observed biotic relationship']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000050.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000050.xml
@@ -308,6 +308,14 @@ def attributetest(row, column):
                 <VALUE>${row['relationship to oxygen']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000051.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000051.xml
@@ -84,6 +84,14 @@ def attributetest(row, column):
                 <TAG>patient sex</TAG>
                 <VALUE>${row['patient sex']}</VALUE>
             </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000052.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000052.xml
@@ -212,6 +212,14 @@ def attributetest(row, column):
                 <VALUE>${row['host storage container temperature']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>

--- a/ena_upload/templates/ENA_template_samples_ERC000053.xml
+++ b/ena_upload/templates/ENA_template_samples_ERC000053.xml
@@ -178,6 +178,14 @@ def attributetest(row, column):
                 <VALUE>${row['culture_or_strain_id']}</VALUE>
             </SAMPLE_ATTRIBUTE>
             </py:if>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL</TAG>
+                <VALUE>${tool_name}</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>SUBMISSION_TOOL_VERSION</TAG>
+                <VALUE>${tool_version}</VALUE>
+            </SAMPLE_ATTRIBUTE>
         </SAMPLE_ATTRIBUTES>
     </SAMPLE>
     </py:for>


### PR DESCRIPTION
This PR will bring back the tool name and tool version to the sample template. This was lost while adding support for all sample checklists. 

With this attribute with also have not the problem we had #31 