### PR TITLE
Bugfix: isa-json not working when tool is not launched in the ENA-upload-cli directory

### DIFF
--- a/ena_upload/json_parsing/characteristic.py
+++ b/ena_upload/json_parsing/characteristic.py
@@ -11,8 +11,8 @@ class IsaBase:
 
     @classmethod
     def validate_json(self, isa_json: Dict[str, str], schema):
-        schema_path = os.path.join(os.curdir, "ena_upload", "json_parsing", "json_schemas", schema)
-
+        base_path = os.path.abspath(os.path.dirname(__file__))
+        schema_path = os.path.join(base_path, 'json_schemas', schema)
         json_file = open(schema_path)
         json_schema = json.load(json_file)
 


### PR DESCRIPTION
This will fix:

```
Traceback (most recent call last):
  File "/home/bedro/.pyenv/versions/3.11.3/bin/ena-upload-cli", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/bedro/.pyenv/versions/3.11.3/lib/python3.11/site-packages/ena_upload/ena_upload.py", line 889, in main
    submission = EnaSubmission.from_isa_json(isa_json, required_assays)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bedro/.pyenv/versions/3.11.3/lib/python3.11/site-packages/ena_upload/json_parsing/ena_submission.py", line 92, in from_isa_json
    validate_isa_json(isa_json)
  File "/home/bedro/.pyenv/versions/3.11.3/lib/python3.11/site-packages/ena_upload/json_parsing/ena_submission.py", line 49, in validate_isa_json
    IsaBase.validate_json(isa_json, EnaSubmission.investigation_schema)
  File "/home/bedro/.pyenv/versions/3.11.3/lib/python3.11/site-packages/ena_upload/json_parsing/characteristic.py", line 16, in validate_json
    json_file = open(schema_path)
                ^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: './ena_upload/json_parsing/json_schemas/investigation_schema.json'
```

When the script is launched outside its original repo. Important to get working for the Galaxy tool wrapper.