### PR TITLE
Increase timeouts and improve handling of high-latency connections

### DIFF
--- a/ena_upload/ena_upload.py
+++ b/ena_upload/ena_upload.py
@@ -39,6 +39,12 @@ class MyFTP_TLS(ftplib.FTP_TLS):
             conn = self.context.wrap_socket(conn,
                                             server_hostname=self.host,
                                             session=self.sock.session)
+            # fix reuse of ssl socket:
+            # https://stackoverflow.com/a/53456626/10971151 and
+            # https://stackoverflow.com/a/70830916/10971151
+            def custom_unwrap():
+                pass
+            conn.unwrap = custom_unwrap
         return conn, size
 
 
@@ -407,7 +413,7 @@ def submit_data(file_paths, password, webin_id):
 
     print("\nConnecting to ftp.webin2.ebi.ac.uk....")
     try:
-        ftps = MyFTP_TLS(timeout=10)
+        ftps = MyFTP_TLS(timeout=120)
         ftps.context.set_ciphers('HIGH:!DH:!aNULL')
         ftps.connect(ftp_host, port=21)
         ftps.auth()


### PR DESCRIPTION
This is a follow up on an issue reported last year: https://github.com/usegalaxy-eu/ena-upload-cli/issues/75

@mthang and I investigated further and found that the instability was due to the high-latency and load between the ftp server and Galaxy Australia. It required two fixes.

1. Increase client timeouts to deal with the higher latency
2. Enhance the existing workaround for dealing with reused ssl sockets based on: https://stackoverflow.com/a/53456626/10971151 and https://stackoverflow.com/a/70830916/10971151