### PR TITLE
Bugfix paired end reads throwing type error

### DIFF
--- a/ena_upload/templates/ENA_template_experiments.xml
+++ b/ena_upload/templates/ENA_template_experiments.xml
@@ -49,7 +49,7 @@ def mandatorytest(row, column, index):
                     </py:if>
                     <py:if test="mandatorytest(row, 'library_layout', index)">
                     <LIBRARY_LAYOUT py:choose="">
-                        <PAIRED py:when="row.library_layout.lower().strip() == 'paired'" NOMINAL_LENGTH="${row.insert_size}" />
+                        <PAIRED py:when="row.library_layout.lower().strip() == 'paired'" NOMINAL_LENGTH="${int(row.insert_size)}" />
                         <SINGLE py:when="row.library_layout.lower().strip() == 'single'" />
                     </LIBRARY_LAYOUT>
                     </py:if>


### PR DESCRIPTION
When 250 is given as value in the metadata for insert_size, it was filled in as 250.0, which is not a valid  xs:nonNegativeInteger value.

Throwing the error: 
```
Traceback (most recent call last):
  File "/home/bedro/.pyenv/versions/3.11.3/envs/ena-upload-python/bin/ena-upload-cli", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/bedro/.pyenv/versions/3.11.3/envs/ena-upload-python/lib/python3.11/site-packages/ena_upload/ena_upload.py", line 1003, in main
    schema_xmls = run_construct(
                  ^^^^^^^^^^^^^^
  File "/home/bedro/.pyenv/versions/3.11.3/envs/ena-upload-python/lib/python3.11/site-packages/ena_upload/ena_upload.py", line 314, in run_construct
    schema_xmls[schema] = construct_xml(schema, stream, xsds[schema])
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bedro/.pyenv/versions/3.11.3/envs/ena-upload-python/lib/python3.11/site-packages/ena_upload/ena_upload.py", line 253, in construct_xml
    validate_xml(xsd, xml_string)
  File "/home/bedro/.pyenv/versions/3.11.3/envs/ena-upload-python/lib/python3.11/site-packages/ena_upload/ena_upload.py", line 201, in validate_xml
    return xmlschema.assertValid(doc)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "src/lxml/etree.pyx", line 3691, in lxml.etree._Validator.assertValid
lxml.etree.DocumentInvalid: Element 'PAIRED', attribute 'NOMINAL_LENGTH': '250.0' is not a valid value of the atomic type 'xs:nonNegativeInteger'., line 15```