### PR TITLE
Add unencrypted checksum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Please check out the [template](https://github.com/ELIXIR-Belgium/ENA-metadata-t
 #### Read info run attributes
 
 Using `read_type`	and `read_label` as header in the columns of ENA run objects will allow you to set information about reads. Values are listed in a comma separated way, without spaces. `read_type` has a controlled vocabulary, which can be found in the [ENA Documentation](https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#json-manifest-file-format). An example tsv file using these attributes can be found in [example_tables/ENA_template_runs_read_info.tsv](/example_tables/ENA_template_runs_read_info.tsv). The same syntax is also applicable for xlsx input files.
+This feature is currently limited to FastQ files.
 
 #### Encrypted files
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ Please check out the [template](https://github.com/ELIXIR-Belgium/ENA-metadata-t
 
 Using `read_type`	and `read_label` as header in the columns of ENA run objects will allow you to set information about reads. Values are listed in a comma separated way, without spaces. `read_type` has a controlled vocabulary, which can be found in the [ENA Documentation](https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#json-manifest-file-format). An example tsv file using these attributes can be found in [example_tables/ENA_template_runs_read_info.tsv](/example_tables/ENA_template_runs_read_info.tsv). The same syntax is also applicable for xlsx input files.
 
+#### Encrypted files
+
+When transferring encrypted files, an additional `unencrypted_checksum` column can be added in the run table. This column should contain the md5 checksum of the unencrypted file, and note that no check is performed on this value.
+This feature is currently limited to FastQ files.
+
 #### Study and experiment custom attributes
 
 Similarly to samples, additional custom attributes can be added to the experiment and study tables by adding columns which headers are named like `experiment_attribute[attribute_name]` and `study_attribute[attribute_name]` in the experiment and study tables, respectively.

--- a/ena_upload/ena_upload.py
+++ b/ena_upload/ena_upload.py
@@ -104,7 +104,7 @@ def check_columns(df, schema, action, dev, auto_action):
             df['scientific_name'] = pd.Series(dtype='str')
     elif schema == 'run':
         optional_columns = ['accession',
-                          'submission_date', 'status', 'file_checksum']
+                          'submission_date', 'status', 'file_checksum', 'unencrypted_checksum']
         # Ensure string dtype for file_checksum
         if 'file_checksum' not in df.columns:
             df['file_checksum'] = pd.Series(dtype='str')
@@ -235,6 +235,8 @@ def generate_stream(schema, targets, Template, center, tool):
             file_attrib.append('read_type')
         if 'read_label' in targets:
             file_attrib.append('read_label')
+        if 'unencrypted_checksum' in targets:
+            file_attrib.append('unencrypted_checksum')
 
         other_attrib = ['alias', 'experiment_alias']
         # Create groups with alias as index

--- a/ena_upload/ena_upload.py
+++ b/ena_upload/ena_upload.py
@@ -104,7 +104,7 @@ def check_columns(df, schema, action, dev, auto_action):
             df['scientific_name'] = pd.Series(dtype='str')
     elif schema == 'run':
         optional_columns = ['accession',
-                          'submission_date', 'status', 'file_checksum', 'unencrypted_checksum']
+                          'submission_date', 'status', 'file_checksum']
         # Ensure string dtype for file_checksum
         if 'file_checksum' not in df.columns:
             df['file_checksum'] = pd.Series(dtype='str')

--- a/ena_upload/templates/ENA_template_FASTQFILE.xml
+++ b/ena_upload/templates/ENA_template_FASTQFILE.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?python
+import pandas as pd
+def attributetest(row, column):
+    if hasattr(row, column) and pd.notna(row[column]) and not str(row[column]).isspace():
+        return True
+?>
+<py:choose xmlns:py="http://genshi.edgewall.org/" test="" xmlns:xi="http://www.w3.org/2001/XInclude">
+<py:when test="attributetest(row, 'unencrypted_checksum')">
+    <FILE filename="${row.file_name}" filetype="fastq" checksum_method="MD5" checksum="${row.file_checksum}" unencrypted_checksum="${row.unencrypted_checksum}">
+    <py:if test="attributetest(row, 'read_label')">
+        <py:for each="rlabel in row.read_label.split(',')">
+        <READ_LABEL>${rlabel.strip()}</READ_LABEL>
+        </py:for>
+    </py:if>
+    <py:if test="attributetest(row, 'read_type')">
+        <py:for each="rtype in row.read_type.split(',')">
+        <xi:include href="ENA_template_READ_TYPE.xml" />
+        </py:for>
+    </py:if>
+    </FILE>
+</py:when>
+<py:otherwise>
+    <FILE filename="${row.file_name}" filetype="fastq" checksum_method="MD5" checksum="${row.file_checksum}">
+    <py:if test="attributetest(row, 'read_label')">
+        <py:for each="rlabel in row.read_label.split(',')">
+        <READ_LABEL>${rlabel.strip()}</READ_LABEL>
+        </py:for>
+    </py:if>
+    <py:if test="attributetest(row, 'read_type')">
+        <py:for each="rtype in row.read_type.split(',')">
+        <xi:include href="ENA_template_READ_TYPE.xml" />
+        </py:for>
+    </py:if>
+    </FILE>
+</py:otherwise>
+</py:choose>

--- a/ena_upload/templates/ENA_template_runs.xml
+++ b/ena_upload/templates/ENA_template_runs.xml
@@ -24,19 +24,8 @@ def mandatorytest(row, column, index):
                 <py:for each="index, row in file_groups.get_group(alias).iterrows()">
                 <py:if test="mandatorytest(row, 'file_type', index)">
                 <py:choose xmlns:py="http://genshi.edgewall.org/" test="">
-                <py:when test="row.file_type.lower().strip() == 'fastq'">
-                    <FILE filename="${row.file_name}" filetype="fastq" checksum_method="MD5" checksum="${row.file_checksum}">
-                        <py:if test="attributetest(row, 'read_label')">
-                        <py:for each="rlabel in row.read_label.split(',')">
-                        <READ_LABEL>${rlabel.strip()}</READ_LABEL>
-                        </py:for>
-                        </py:if>
-                        <py:if test="attributetest(row, 'read_type')">
-                        <py:for each="rtype in row.read_type.split(',')">
-                        <xi:include href="ENA_template_READ_TYPE.xml" />
-                        </py:for>
-                        </py:if>
-                    </FILE>
+                    <py:when test="row.file_type.lower().strip() == 'fastq'">
+                         <xi:include href="ENA_template_FASTQFILE.xml" />
                     </py:when>
                     <py:otherwise>
                         <xi:include href="ENA_template_FILE.xml" />

--- a/example_tables/ENA_template_runs_md5sums_unencrypted.tsv
+++ b/example_tables/ENA_template_runs_md5sums_unencrypted.tsv
@@ -1,0 +1,4 @@
+alias	experiment_alias	file_name	file_type	file_checksum	unencrypted_checksum
+run_alias_1a	experiment_alias_7a	ENA_TEST2.R1.fastq.gz	fastq	3e69af1f875fab020aed82f5edbc1f03	3e69af1f875fab020aed82f5edbc1f03
+run_alias_1a	experiment_alias_7a	ENA_TEST2.R2.fastq.gz	fastq	3e69af1f875fab020aed82f5edbc1f03	3e69af1f875fab020aed82f5edbc1f03
+run_alias_3c	experiment_alias_9c	ENA_TEST1.R1.fastq.gz	fastq	3e69af1f875fab020aed82f5edbc1f03	3e69af1f875fab020aed82f5edbc1f03


### PR DESCRIPTION
Using ena-upload-cli to prepare XMl files for EGA submission, I need to be able to inject the `unencrypted_checksum` in the XML. This PR adds support for a new `unencrypted_checksum` column in the run table which ends up as 
```
 <FILE filename="ENA_TEST2.R1.fastq.gz" filetype="fastq" checksum_method="MD5" checksum="3e69af1f875fab020aed82f5edbc1f03" unencrypted_checksum="3e69af1f875fab020aed82f5edbc1f03">
    </FILE>
```

in the run.xml.
