### PR TITLE
Add run-table guardrails for multi-FASTQ read types

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,12 @@ Please check out the [template](https://github.com/ELIXIR-Belgium/ENA-metadata-t
 
 #### Read info run attributes
 
-Using `read_type`	and `read_label` as header in the columns of ENA run objects will allow you to set information about reads. Values are listed in a comma separated way, without spaces. `read_type` has a controlled vocabulary, which can be found in the [ENA Documentation](https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#json-manifest-file-format). An example tsv file using these attributes can be found in [example_tables/ENA_template_runs_read_info.tsv](/example_tables/ENA_template_runs_read_info.tsv). The same syntax is also applicable for xlsx input files.
+Using `read_type`	and `read_label` as header in the columns of ENA run objects will allow you to set information about reads. Values are listed in a comma separated way, without spaces. `read_type` has a controlled vocabulary, which can be found in the [ENA Documentation](https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#json-manifest-file-format). Example tsv files using these attributes can be found in [example_tables/ENA_template_runs_read_info.tsv](/example_tables/ENA_template_runs_read_info.tsv) and [example_tables/ENA_template_runs_multi_fastq.tsv](/example_tables/ENA_template_runs_multi_fastq.tsv). The same syntax is also applicable for xlsx input files.
 This feature is currently limited to FastQ files.
+
+For ordinary paired-end data, use one run alias per R1/R2 pair. Do not place multiple paired samples or libraries under one run alias with every file marked as `paired`; ENA accepts `paired` as one pair of FASTQ files in a run. Multiple paired-end samples should therefore have separate sample, experiment and run aliases.
+
+Run aliases with more than two FastQ files are treated as multi-fastq submissions. In that case, every FastQ file in the run must define valid `read_type` values, and at least one file must use a barcode read type such as `cell_barcode`, `umi_barcode`, `feature_barcode`, `sample_barcode` or `spatial_barcode`. This supports true multi-fastq submissions such as single-cell data where a file can use multiple comma-separated values, for example `paired,umi_barcode`.
 
 #### Encrypted files
 

--- a/ena_upload/ena_upload.py
+++ b/ena_upload/ena_upload.py
@@ -212,35 +212,53 @@ def parse_read_types(value):
     return [read_type.strip().lower() for read_type in str(value).split(',')]
 
 
-def validate_run_table(run_df):
+def clean_value(value):
+    return str(value).strip() if is_filled(value) else ''
+
+
+def file_label(row, index):
+    if 'file_name' in row.index and is_filled(row['file_name']):
+        return row['file_name']
+
+    return index
+
+
+def validate_read_type_values(run_df):
     errors = []
+    if 'read_type' not in run_df.columns:
+        return errors
 
-    if 'file_type' in run_df.columns:
-        file_type_column = 'file_type'
-    elif 'file_format' in run_df.columns:
-        file_type_column = 'file_format'
-    else:
-        file_type_column = None
+    for index, row in run_df.iterrows():
+        alias = row['alias'] if 'alias' in run_df.columns else index
+        read_types = parse_read_types(row['read_type'])
 
-    if 'read_type' in run_df.columns:
-        for index, row in run_df.iterrows():
-            read_types = parse_read_types(row['read_type'])
-            alias = row['alias'] if 'alias' in run_df.columns else index
-            if '' in read_types:
-                errors.append(
-                    f'In run, alias: "{alias}". Read type contains an empty '
-                    f'value at row "{index}".'
-                )
-
-            invalid_read_types = sorted(
-                set(read_types) - READ_TYPE_VALUES - {''}
+        if '' in read_types:
+            errors.append(
+                f'In run, alias: "{alias}". Read type contains an empty '
+                f'value at row "{index}".'
             )
-            if invalid_read_types:
-                errors.append(
-                    f'In run, alias: "{alias}". Invalid read_type value(s) '
-                    f'"{", ".join(invalid_read_types)}". Allowed values are: '
-                    f'{", ".join(sorted(READ_TYPE_VALUES))}.'
-                )
+
+        invalid_read_types = sorted(set(read_types) - READ_TYPE_VALUES - {''})
+        if invalid_read_types:
+            errors.append(
+                f'In run, alias: "{alias}". Invalid read_type value(s) '
+                f'"{", ".join(invalid_read_types)}". Allowed values are: '
+                f'{", ".join(sorted(READ_TYPE_VALUES))}.'
+            )
+
+    return errors
+
+
+def validate_run_table(run_df):
+    errors = validate_read_type_values(run_df)
+
+    file_type_column = next(
+        (
+            column for column in ['file_type', 'file_format']
+            if column in run_df.columns
+        ),
+        None
+    )
 
     if 'alias' not in run_df.columns:
         if errors:
@@ -249,107 +267,66 @@ def validate_run_table(run_df):
 
     for alias, group in run_df.groupby('alias', dropna=False):
         if 'experiment_alias' in group.columns:
-            experiment_aliases = {
-                str(experiment_alias).strip()
+            experiment_aliases = sorted({
+                clean_value(experiment_alias)
                 for experiment_alias in group['experiment_alias']
                 if is_filled(experiment_alias)
-            }
+            })
             if len(experiment_aliases) > 1:
                 errors.append(
                     f'In run, alias: "{alias}". A run can reference only one '
                     f'experiment_alias, but found: '
-                    f'{", ".join(sorted(experiment_aliases))}. Use a unique '
+                    f'{", ".join(experiment_aliases)}. Use a unique '
                     f'run alias for each experiment.'
                 )
 
         if file_type_column is None:
             continue
 
-        file_types = group[file_type_column].apply(
-            lambda file_type: str(file_type).strip().lower()
-            if is_filled(file_type) else ''
-        )
-        fastq_group = group[file_types == 'fastq']
-
-        if fastq_group.empty:
+        fastq_group = group[
+            group[file_type_column].apply(clean_value).str.lower() == 'fastq'
+        ]
+        if len(fastq_group) <= 2:
             continue
 
-        read_types_by_index = {}
+        read_types_by_file = {}
         for index, row in fastq_group.iterrows():
-            if 'read_type' in run_df.columns:
-                read_types = parse_read_types(row['read_type'])
-            else:
-                read_types = []
-            read_types_by_index[index] = read_types
+            read_types = (
+                parse_read_types(row['read_type'])
+                if 'read_type' in run_df.columns else []
+            )
+            read_types_by_file[file_label(row, index)] = read_types
 
-            if 'single' in read_types and 'paired' in read_types:
-                errors.append(
-                    f'In run, alias: "{alias}". File "{row.file_name}" cannot '
-                    f'use read_type values "single" and "paired" together.'
-                )
-
-        rows_with_read_type = {
-            index for index, read_types in read_types_by_index.items()
-            if read_types
-        }
-        if not rows_with_read_type:
-            if len(fastq_group) > 2:
-                errors.append(
-                    f'In run, alias: "{alias}". {len(fastq_group)} FASTQ '
-                    f'files were provided without read_type values. ENA '
-                    f'requires read_type values for multi-fastq runs. Split '
-                    f'ordinary paired-end data into one run alias per R1/R2 '
-                    f'pair, or use barcode read types for true multi-fastq '
-                    f'submissions.'
-                )
+        missing_files = [
+            filename for filename, read_types in read_types_by_file.items()
+            if not read_types
+        ]
+        if missing_files:
+            errors.append(
+                f'In run, alias: "{alias}". {len(fastq_group)} FASTQ files '
+                f'were provided, so ENA requires read_type values. Missing '
+                f'read_type for: {", ".join(map(str, missing_files))}.'
+            )
             continue
 
-        if len(rows_with_read_type) != len(fastq_group):
-            missing_files = [
-                row.file_name
-                for index, row in fastq_group.iterrows()
-                if index not in rows_with_read_type
-            ]
-            errors.append(
-                f'In run, alias: "{alias}". read_type is set for only some '
-                f'FASTQ files. Missing read_type for: '
-                f'{", ".join(missing_files)}.'
-            )
-
-        paired_files = [
-            index for index, read_types in read_types_by_index.items()
-            if 'paired' in read_types
-        ]
-        single_files = [
-            index for index, read_types in read_types_by_index.items()
-            if 'single' in read_types
-        ]
-        multi_fastq_read_types = {
+        all_read_types = {
             read_type
-            for read_types in read_types_by_index.values()
+            for read_types in read_types_by_file.values()
             for read_type in read_types
-        } & MULTI_FASTQ_READ_TYPES
+        }
+        paired_file_count = sum(
+            'paired' in read_types
+            for read_types in read_types_by_file.values()
+        )
 
-        if paired_files and len(paired_files) != 2:
+        if paired_file_count not in [0, 2]:
             errors.append(
-                f'In run, alias: "{alias}". {len(paired_files)} FASTQ files '
+                f'In run, alias: "{alias}". {paired_file_count} FASTQ files '
                 f'are marked with read_type "paired". ENA expects exactly '
                 f'two paired FASTQ files in one run.'
             )
 
-        if single_files and len(fastq_group) != 1:
-            errors.append(
-                f'In run, alias: "{alias}". read_type "single" can only be '
-                f'used with one FASTQ file in a run.'
-            )
-
-        if single_files and paired_files:
-            errors.append(
-                f'In run, alias: "{alias}". read_type values "single" and '
-                f'"paired" cannot be mixed in one run.'
-            )
-
-        if len(fastq_group) > 2 and not multi_fastq_read_types:
+        if not all_read_types & MULTI_FASTQ_READ_TYPES:
             errors.append(
                 f'In run, alias: "{alias}". {len(fastq_group)} FASTQ files '
                 f'were provided with only simple read_type values. ENA '

--- a/ena_upload/ena_upload.py
+++ b/ena_upload/ena_upload.py
@@ -30,6 +30,19 @@ SCHEMA_TYPES = ['study', 'experiment', 'run', 'sample']
 STATUS_CHANGES = {'ADD': 'ADDED', 'MODIFY': 'MODIFIED',
               'CANCEL': 'CANCELLED', 'RELEASE': 'RELEASED'}
 
+READ_TYPE_VALUES = {
+    'single',
+    'paired',
+    'cell_barcode',
+    'umi_barcode',
+    'feature_barcode',
+    'sample_barcode',
+    'spatial_barcode',
+}
+
+MULTI_FASTQ_READ_TYPES = READ_TYPE_VALUES - {'single', 'paired'}
+
+
 class MyFTP_TLS(ftplib.FTP_TLS):
     """Explicit FTPS, with shared TLS session"""
 
@@ -188,6 +201,168 @@ def check_file_checksum(df):
     return s.all()
 
 
+def is_filled(value):
+    return pd.notna(value) and not str(value).isspace()
+
+
+def parse_read_types(value):
+    if not is_filled(value):
+        return []
+
+    return [read_type.strip().lower() for read_type in str(value).split(',')]
+
+
+def validate_run_table(run_df):
+    errors = []
+
+    if 'file_type' in run_df.columns:
+        file_type_column = 'file_type'
+    elif 'file_format' in run_df.columns:
+        file_type_column = 'file_format'
+    else:
+        file_type_column = None
+
+    if 'read_type' in run_df.columns:
+        for index, row in run_df.iterrows():
+            read_types = parse_read_types(row['read_type'])
+            alias = row['alias'] if 'alias' in run_df.columns else index
+            if '' in read_types:
+                errors.append(
+                    f'In run, alias: "{alias}". Read type contains an empty '
+                    f'value at row "{index}".'
+                )
+
+            invalid_read_types = sorted(
+                set(read_types) - READ_TYPE_VALUES - {''}
+            )
+            if invalid_read_types:
+                errors.append(
+                    f'In run, alias: "{alias}". Invalid read_type value(s) '
+                    f'"{", ".join(invalid_read_types)}". Allowed values are: '
+                    f'{", ".join(sorted(READ_TYPE_VALUES))}.'
+                )
+
+    if 'alias' not in run_df.columns:
+        if errors:
+            raise ValueError('\n'.join(errors))
+        return
+
+    for alias, group in run_df.groupby('alias', dropna=False):
+        if 'experiment_alias' in group.columns:
+            experiment_aliases = {
+                str(experiment_alias).strip()
+                for experiment_alias in group['experiment_alias']
+                if is_filled(experiment_alias)
+            }
+            if len(experiment_aliases) > 1:
+                errors.append(
+                    f'In run, alias: "{alias}". A run can reference only one '
+                    f'experiment_alias, but found: '
+                    f'{", ".join(sorted(experiment_aliases))}. Use a unique '
+                    f'run alias for each experiment.'
+                )
+
+        if file_type_column is None:
+            continue
+
+        file_types = group[file_type_column].apply(
+            lambda file_type: str(file_type).strip().lower()
+            if is_filled(file_type) else ''
+        )
+        fastq_group = group[file_types == 'fastq']
+
+        if fastq_group.empty:
+            continue
+
+        read_types_by_index = {}
+        for index, row in fastq_group.iterrows():
+            if 'read_type' in run_df.columns:
+                read_types = parse_read_types(row['read_type'])
+            else:
+                read_types = []
+            read_types_by_index[index] = read_types
+
+            if 'single' in read_types and 'paired' in read_types:
+                errors.append(
+                    f'In run, alias: "{alias}". File "{row.file_name}" cannot '
+                    f'use read_type values "single" and "paired" together.'
+                )
+
+        rows_with_read_type = {
+            index for index, read_types in read_types_by_index.items()
+            if read_types
+        }
+        if not rows_with_read_type:
+            if len(fastq_group) > 2:
+                errors.append(
+                    f'In run, alias: "{alias}". {len(fastq_group)} FASTQ '
+                    f'files were provided without read_type values. ENA '
+                    f'requires read_type values for multi-fastq runs. Split '
+                    f'ordinary paired-end data into one run alias per R1/R2 '
+                    f'pair, or use barcode read types for true multi-fastq '
+                    f'submissions.'
+                )
+            continue
+
+        if len(rows_with_read_type) != len(fastq_group):
+            missing_files = [
+                row.file_name
+                for index, row in fastq_group.iterrows()
+                if index not in rows_with_read_type
+            ]
+            errors.append(
+                f'In run, alias: "{alias}". read_type is set for only some '
+                f'FASTQ files. Missing read_type for: '
+                f'{", ".join(missing_files)}.'
+            )
+
+        paired_files = [
+            index for index, read_types in read_types_by_index.items()
+            if 'paired' in read_types
+        ]
+        single_files = [
+            index for index, read_types in read_types_by_index.items()
+            if 'single' in read_types
+        ]
+        multi_fastq_read_types = {
+            read_type
+            for read_types in read_types_by_index.values()
+            for read_type in read_types
+        } & MULTI_FASTQ_READ_TYPES
+
+        if paired_files and len(paired_files) != 2:
+            errors.append(
+                f'In run, alias: "{alias}". {len(paired_files)} FASTQ files '
+                f'are marked with read_type "paired". ENA expects exactly '
+                f'two paired FASTQ files in one run.'
+            )
+
+        if single_files and len(fastq_group) != 1:
+            errors.append(
+                f'In run, alias: "{alias}". read_type "single" can only be '
+                f'used with one FASTQ file in a run.'
+            )
+
+        if single_files and paired_files:
+            errors.append(
+                f'In run, alias: "{alias}". read_type values "single" and '
+                f'"paired" cannot be mixed in one run.'
+            )
+
+        if len(fastq_group) > 2 and not multi_fastq_read_types:
+            errors.append(
+                f'In run, alias: "{alias}". {len(fastq_group)} FASTQ files '
+                f'were provided with only simple read_type values. ENA '
+                f'multi-fastq runs need at least one barcode read_type '
+                f'({", ".join(sorted(MULTI_FASTQ_READ_TYPES))}). For multiple '
+                f'paired-end samples or libraries, use separate sample, '
+                f'experiment and run aliases for each pair.'
+            )
+
+    if errors:
+        raise ValueError('\n'.join(errors))
+
+
 def validate_xml(xsd, xml):
     '''
     validate xml against xsd scheme
@@ -225,6 +400,8 @@ def generate_stream(schema, targets, Template, center, tool):
             extra_attributes[column] = match.group(1)
 
     if schema == 'run':
+        validate_run_table(targets)
+
         # These attributes are required for rendering
         # the run xml templates
         # Adding backwards compatibility for file_format
@@ -965,6 +1142,11 @@ def main():
         if 'run' in schema_targets:
             # a dictionary of filename:file_path
             df = schema_targets['run']
+            try:
+                validate_run_table(df)
+            except ValueError as error:
+                sys.exit(f"Oops:\n{error}")
+
             file_paths = {}
             if args.data:
                 for path in args.data:

--- a/example_tables/ENA_template_runs_multi_fastq.tsv
+++ b/example_tables/ENA_template_runs_multi_fastq.tsv
@@ -1,0 +1,4 @@
+alias	experiment_alias	file_name	file_type	read_type
+run_alias_1a	experiment_alias_7a	ENA_TEST2.I1.fastq.gz	fastq	umi_barcode,cell_barcode
+run_alias_1a	experiment_alias_7a	ENA_TEST2.R1.fastq.gz	fastq	paired
+run_alias_1a	experiment_alias_7a	ENA_TEST2.R2.fastq.gz	fastq	paired

--- a/tests/test_ena_upload.py
+++ b/tests/test_ena_upload.py
@@ -1,0 +1,139 @@
+import pandas as pd
+import pytest
+
+from ena_upload.ena_upload import validate_run_table
+
+
+def test_validate_run_table_accepts_simple_paired_fastq_without_read_type():
+    run_df = pd.DataFrame(
+        [
+            {
+                "alias": "run_1",
+                "experiment_alias": "experiment_1",
+                "file_name": "sample_1_R1.fastq.gz",
+                "file_type": "fastq",
+            },
+            {
+                "alias": "run_1",
+                "experiment_alias": "experiment_1",
+                "file_name": "sample_1_R2.fastq.gz",
+                "file_type": "fastq",
+            },
+        ]
+    )
+
+    validate_run_table(run_df)
+
+
+def test_validate_run_table_accepts_true_multi_fastq_read_types():
+    run_df = pd.DataFrame(
+        [
+            {
+                "alias": "run_1",
+                "experiment_alias": "experiment_1",
+                "file_name": "single_cell_I1.fastq.gz",
+                "file_type": "fastq",
+                "read_type": "feature_barcode",
+            },
+            {
+                "alias": "run_1",
+                "experiment_alias": "experiment_1",
+                "file_name": "single_cell_R1.fastq.gz",
+                "file_type": "fastq",
+                "read_type": "paired,umi_barcode",
+            },
+            {
+                "alias": "run_1",
+                "experiment_alias": "experiment_1",
+                "file_name": "single_cell_R2.fastq.gz",
+                "file_type": "fastq",
+                "read_type": "sample_barcode",
+            },
+            {
+                "alias": "run_1",
+                "experiment_alias": "experiment_1",
+                "file_name": "single_cell_R3.fastq.gz",
+                "file_type": "fastq",
+                "read_type": "paired,cell_barcode",
+            },
+        ]
+    )
+
+    validate_run_table(run_df)
+
+
+def test_validate_run_table_rejects_paired_only_multi_fastq():
+    run_df = pd.DataFrame(
+        [
+            {
+                "alias": "run_merged",
+                "experiment_alias": "experiment_1",
+                "file_name": "sample_1_R1.fastq.gz",
+                "file_format": "fastq",
+                "read_type": "paired",
+            },
+            {
+                "alias": "run_merged",
+                "experiment_alias": "experiment_1",
+                "file_name": "sample_1_R2.fastq.gz",
+                "file_format": "fastq",
+                "read_type": "paired",
+            },
+            {
+                "alias": "run_merged",
+                "experiment_alias": "experiment_1",
+                "file_name": "sample_2_R1.fastq.gz",
+                "file_format": "fastq",
+                "read_type": "paired",
+            },
+            {
+                "alias": "run_merged",
+                "experiment_alias": "experiment_1",
+                "file_name": "sample_2_R2.fastq.gz",
+                "file_format": "fastq",
+                "read_type": "paired",
+            },
+        ]
+    )
+
+    with pytest.raises(ValueError, match="only simple read_type values"):
+        validate_run_table(run_df)
+
+
+def test_validate_run_table_rejects_invalid_read_type():
+    run_df = pd.DataFrame(
+        [
+            {
+                "alias": "run_1",
+                "experiment_alias": "experiment_1",
+                "file_name": "sample_1_R1.fastq.gz",
+                "file_type": "fastq",
+                "read_type": "forward",
+            },
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Invalid read_type"):
+        validate_run_table(run_df)
+
+
+def test_validate_run_table_rejects_multiple_experiments_per_run():
+    run_df = pd.DataFrame(
+        [
+            {
+                "alias": "run_merged",
+                "experiment_alias": "experiment_1",
+                "file_name": "sample_1_R1.fastq.gz",
+                "file_type": "fastq",
+            },
+            {
+                "alias": "run_merged",
+                "experiment_alias": "experiment_2",
+                "file_name": "sample_2_R1.fastq.gz",
+                "file_type": "fastq",
+            },
+        ]
+    )
+
+    with pytest.raises(ValueError, match="can reference only one experiment_alias"):
+        validate_run_table(run_df)


### PR DESCRIPTION
Adds validation for FASTQ run metadata so invalid `read_type` configurations fail before ENA submission. This catches paired-only multi-file runs, invalid `read_type` values, and run aliases pointing to multiple experiments.

Also adds a 3-file multi-FASTQ example table and tests for paired-end and barcode-style multi-FASTQ cases.

This will close #129